### PR TITLE
fix: Error in git regex failing runs in GitHub Actions

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -10,7 +10,7 @@ interface CommandOutput {
 }
 
 const WHOLE =
-  /^(?:(?<proto>\w+):\/\/)?(?:(?<username>\w+)(?::(?<pass>.+))?@)?(?<host>.+?)(?::(?<port>\d+))?(:|\/)(?<path>.*)\.git$/m;
+  /^(?:(?<proto>\w+):\/\/)?(?:(?<username>\w+)(?::(?<pass>.+))?@)?(?<host>.+?)(?::(?<port>\d+))?(:|\/)(?<path>.*?)(\.git)?$/m;
 
 @injectable()
 export class Git {


### PR DESCRIPTION
In testing in a private repo to determine whether or not automation works as expected (and to perhaps update documentation on how to utilize this in the larger Git Providers (Github, Gitlab, and I guess to be thorough BitBucket, even though I hate it). 

For some reason, Github Actions (could possibly be the checkout action?) sets  the origin to be an HTTP URL without the `.git` value, which breaks. This fixes it.